### PR TITLE
Update requirements.txt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ibm_mdm_mcp_server"
-version = "1.0.9"
+version = "1.0.10"
 description = "A Model Context Protocol (MCP) server for IBM Master Data Management (MDM) services"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -59,7 +59,7 @@ dependencies = [
     "httpx>=0.28.0",
     "PyJWT>=2.10.0",
     "urllib3>=2.6.3",
-    "Authlib>=1.6.0",
+    "Authlib>=1.6.5",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ requests>=2.32.0
 httpx>=0.28.0
 PyJWT>=2.10.0
 urllib3>=2.6.3
-Authlib>=1.6.0
+Authlib>=1.6.5
 
 # Testing Dependencies
 pytest>=8.3.0


### PR DESCRIPTION
- Updates the Authlib version to `1.6.5`.
- Causes the WxO MCP Toolkit installation failure:

```
ERROR: Cannot install -r req.txt (line 2) and Authlib==1.6.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested Authlib==1.6.0
    fastmcp 2.14.0 depends on authlib>=1.6.5
```