### PR TITLE
cpd-bug fixes

### DIFF
--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -259,6 +259,8 @@ def configure_environment() -> Dict[str, str]:
         env_vars["M360_TARGET_PLATFORM"] = "cpd"
         env_vars["API_CPD_BASE_URL"] = get_user_input("Enter CPD Base URL")
         env_vars["API_CPD_AUTH_URL"] = get_user_input("Enter CPD Auth URL")
+        env_vars["ZEN_BASE_URL"] = get_user_input("Enter Zen Base URL")
+        env_vars["MDM_INSTANCE_ID"] = get_user_input("Enter MDM Instance ID")
         env_vars["API_USERNAME"] = get_user_input("Enter Username")
         env_vars["API_PASSWORD"] = get_user_input("Enter Password", secure=True)
     

--- a/src/common/auth/authentication_manager.py
+++ b/src/common/auth/authentication_manager.py
@@ -16,6 +16,7 @@ import urllib3
 import base64
 import jwt
 import threading
+import time
 from typing import Optional, Dict, Tuple
 from datetime import datetime, timedelta
 
@@ -132,6 +133,17 @@ class AuthenticationManager:
         
         # Token cache (injected or created)
         self._token_cache = token_cache or TokenCache()
+        # ─── Added for MDM service token ─────────────────────────────────
+        self.zen_base_url = Config.ZEN_BASE_URL.rstrip('/')
+        self.mdm_instance_id = Config.MDM_INSTANCE_ID
+        # Optional safety check
+        if not self.zen_base_url:
+            raise ValueError("ZEN_BASE_URL is not set in config")
+        if not self.mdm_instance_id:
+            raise ValueError("MDM_INSTANCE_ID is not set in config")
+        self._service_token = None
+        self._service_token_expiry = 0.0
+        # ──────────────────────────────────────────────────────────────────
         self.logger = logger
     
     def _decode_jwt_expiry(self, token: str) -> Optional[datetime]:
@@ -248,7 +260,48 @@ class AuthenticationManager:
         except Exception as e:
             self.logger.error(f"Unexpected error fetching CPD token: {e}")
             raise
-    
+
+    def _fetch_mdm_service_token(self, zen_token: str) -> str:
+        """
+        Fetch MDM service-specific token using the Zen platform token
+        """
+        url = f"{self.zen_base_url}/zen-data/v2/serviceInstance/token"
+
+        headers = {
+            "Authorization": f"Bearer {zen_token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json"
+        }
+
+        payload = {
+            "serviceInstanceID": self.mdm_instance_id
+        }
+
+        self.logger.info(f"Fetching MDM service token for instance {self.mdm_instance_id}")
+
+        response = requests.post(
+            url,
+            json=payload,
+            headers=headers,
+            verify=self.verify_ssl,
+            timeout=self.timeout
+        )
+
+        response.raise_for_status()
+        data = response.json()
+
+        service_token = data.get("AccessToken")
+        if not service_token:
+            raise ValueError("No 'AccessToken' field in MDM service token response")
+
+        # Expiry handling (fallback to 1 hour)
+        expires_in = data.get("expires_in", 3600)
+        self._service_token_expiry = time.time() + expires_in - 120
+
+        self.logger.info(f"MDM service token received (expires in ~{expires_in}s)")
+
+        return service_token
+
     def _fetch_cloud_token(self) -> Tuple[str, datetime]:
         """
         Fetch a new access token from the Cloud IAM API.
@@ -345,18 +398,20 @@ class AuthenticationManager:
         """
         # Try to get cached token
         token = self._token_cache.get()
-        
+
         if token is not None:
             self.logger.debug("Using cached token")
-            return token
-        
-        # Need to fetch new token
-        self.logger.info("No valid cached token, fetching new one")
-        token, expiry_time = self._fetch_new_token()
-        
-        # Cache the new token
-        self._token_cache.set(token, expiry_time)
-        
+        else:
+            self.logger.info("No valid cached token, fetching new one")
+            token, expiry_time = self._fetch_new_token()
+            self._token_cache.set(token, expiry_time)
+
+        # For CPD: exchange platform token for MDM service token
+        if self.platform == "cpd":
+            service_token = self._fetch_mdm_service_token(token)
+            self._service_token = service_token
+            return service_token
+
         return token
     
     def get_auth_headers(self) -> Dict[str, str]:
@@ -419,3 +474,6 @@ class AuthenticationManager:
         """
         self.logger.info("Invalidating token")
         self._token_cache.invalidate()
+        # Added: also clear service token
+        self._service_token = None
+        self._service_token_expiry = 0.0

--- a/src/common/domain/crn_validator.py
+++ b/src/common/domain/crn_validator.py
@@ -8,7 +8,7 @@ CRN (Cloud Resource Name) validation utility for IBM MDM MCP server.
 
 CRN Format:
 - Full format: "crn:v1:staging:public:mdm-oc:us-south:a/account123:instance456::"
-- On-Prem format: ":::::::tenant01::"
+- On-Prem format: ":::::::1::"
 
 The tenant ID is the instance field (index 7).
 """
@@ -21,7 +21,7 @@ from config import Config
 logger = logging.getLogger(__name__)
 
 # Default CRN for On-Prem deployments
-DEFAULT_CRN = ":::::::tenant01::"
+DEFAULT_CRN = ":::::::1::"
 
 # Get cloud CRN from config
 CLOUD_CRN = Config.API_CLOUD_CRN
@@ -69,7 +69,7 @@ def validate_crn(crn: str) -> Tuple[bool, Optional[str], Optional[str]]:
     
     return False, None, (
         "CRN format is invalid. Expected formats:\n"
-        "  - On-Prem: ':::::::tenant_id::' (e.g., ':::::::tenant01::')\n"
+        "  - On-Prem: ':::::::tenant_id::' (e.g., ':::::::1::')\n"
         "  - Full: 'crn:version:env:visibility:service:region:account:instance::' "
         "(e.g., 'crn:v1:staging:public:mdm-oc:us-south:a/account123:instance456::')"
     )
@@ -157,7 +157,7 @@ def format_crn_error_response(crn: str, error_msg: str) -> dict:
         message=error_msg,
         default_crn=DEFAULT_CRN,
         valid_formats=[
-            "On-Prem: ':::::::tenant_id::' (e.g., ':::::::tenant01::')",
+            "On-Prem: ':::::::tenant_id::' (e.g., ':::::::1::')",
             "Full: 'crn:version:env:visibility:service:region:account:instance::'"
         ]
     )

--- a/src/config.py
+++ b/src/config.py
@@ -33,5 +33,7 @@ class Config:
         API_BASE_URL = API_CLOUD_BASE_URL
     elif M360_TARGET_PLATFORM == "cpd":
         API_BASE_URL = API_CPD_BASE_URL
+        ZEN_BASE_URL = os.getenv("ZEN_BASE_URL")
+        MDM_INSTANCE_ID = os.getenv("MDM_INSTANCE_ID")
     else:
         raise ValueError("Invalid platform specified")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,7 @@ def mock_context():
 @pytest.fixture
 def sample_crn_onprem():
     """Provide a sample on-premise CRN for testing."""
-    return ":::::::tenant01::"
+    return ":::::::1::"
 
 
 @pytest.fixture

--- a/tests/test_common/test_crn_validation.py
+++ b/tests/test_common/test_crn_validation.py
@@ -116,7 +116,7 @@ class TestTenantIDExtraction:
     """Test tenant ID extraction from CRNs."""
 
     @pytest.mark.parametrize("crn,expected_tenant_id", [
-        (":::::::tenant01::", "tenant01"),
+        (":::::::1::", "tenant01"),
         (":::::::production_tenant::", "production_tenant"),
         ("crn:v1:staging:public:mdm-oc:us-south:a/account123:instance456::", "instance456"),
     ])

--- a/tests/test_common/test_session_store.py
+++ b/tests/test_common/test_session_store.py
@@ -160,7 +160,7 @@ class TestErrorMessageFormat:
             "To fix this error:\n"
             "1. First call get_data_model() in the same session:\n"
             "   get_data_model(\n"
-            "       tenant_id=\":::::::tenant01::\",\n"
+            "       tenant_id=\":::::::1::\",\n"
             "       format=\"enhanced_compact\"\n"
             "   )\n\n"
             "2. Review the data model to understand:\n"

--- a/tests/test_model_ms/test_model_tools.py
+++ b/tests/test_model_ms/test_model_tools.py
@@ -152,7 +152,7 @@ class TestGetDataModelSuccess:
         mock_service_class.return_value = mock_service
         expected_model = {"entity_types": [], "attribute_type_definitions": {}}
         mock_service.get_data_model.return_value = expected_model
-        custom_crn = ":::::::tenant01::"
+        custom_crn = ":::::::1::"
         
         import model_ms.model.tools as tools_module
         tools_module._model_service = mock_service
@@ -274,7 +274,7 @@ class TestGetDataModelIntegration:
         mock_session_store_getter.return_value = mock_session_store
         
         # Mock CRN validation to return valid CRN and tenant
-        mock_crn_validator.return_value = (":::::::tenant01::", "tenant01")
+        mock_crn_validator.return_value = (":::::::1::", "tenant01")
         
         mock_context.session_id = "test-session-123"
         


### PR DESCRIPTION
# Fix Authentication Issues for CPD (Cloud Pak for Data) Platform

## Description

This PR resolves two critical authentication-related issues that were preventing the MCP server from successfully calling the IBM MDM APIs when running against a CPD (Cloud Pak for Data) environment:

1. **Authentication Error when calling APIs**  
   - Root cause: The server was using the **Zen platform token** (obtained from `/icp4d-api/v1/authorize`) directly for MDM API calls (`/mdm/v1/...`).  
   - Problem: MDM service rejects the Zen token → 401 Unauthorized.  
   - Fix: Added logic to exchange the Zen token for a **MDM service-specific token** using the `/zen-data/v2/serviceInstance/token` endpoint.

2. **Incorrect CRN in CPD requests**  
   - **Problem**: The default CRN was set to `:::::::tenant01::` which was invalid or mismatched the actual tenant in this CPD cluster.  
   - **Fix**: Manually updated the default CRN to `:::::::1::`
   - This ensures proper tenant context in requests that require CRN (search, data model, etc.).

## Changes Made

- Added two new environment variables:
  - `ZEN_BASE_URL` – base URL of the CPD/Zen platform (without instance/mdm path)
  - `MDM_INSTANCE_ID` – the MDM instance ID (e.g. `1770044090874677`)

- In `authentication_manager.py`:
  - Added logic to read `ZEN_BASE_URL` and `MDM_INSTANCE_ID`
  - Added `_fetch_mdm_service_token()` method that uses the Zen token to get the MDM service token
  - Modified `_ensure_valid_token()` to return the **MDM service token** (instead of Zen token) when platform is `cpd`
  - All MDM API calls now automatically use the service token via `get_auth_headers()`

- Improved token invalidation to also clear the service token cache

- Added debug/info logging for service token fetching and usage

- Updated all occurrences of `:::::::tenant01::` to `:::::::1::` 

## Working Evidences

<img width="1667" height="959" alt="Screenshot 2026-02-06 at 7 25 28 PM" src="https://github.com/user-attachments/assets/9db782a9-ecdd-4da0-98fa-a3bc4464185a" />
<img width="1291" height="758" alt="Screenshot 2026-02-06 at 7 25 46 PM" src="https://github.com/user-attachments/assets/b9ff5b30-a39a-4544-8895-920887be39f4" />
<img width="1044" height="850" alt="Screenshot 2026-02-06 at 7 26 03 PM" src="https://github.com/user-attachments/assets/1fb0ed0a-8e6c-4366-8374-aa1622c954e4" />


**Logs from Claude:**

```

2026-02-06T13:38:49.886Z [ibm-mdm] [info] Message from client: {"method":"tools/call","params":{"name":"search_master_data","arguments":{"request":{"search_type":"entity","query":{"expressions":[{"property":"*","condition":"contains","value":""}]},"filters":[{"type":"entity","values":["person"]}],"limit":1,"include_total_count":true}}},"jsonrpc":"2.0","id":4} { metadata: undefined }
2026-02-06 19:08:49,888 - mcp.server.lowlevel.server - INFO - Processing request of type CallToolRequest
2026-02-06 19:08:49,888 - common.domain.crn_validator - INFO - Using default on-prem CRN for cpd platform: :::::::1::
2026-02-06 19:08:49,889 - common.domain.crn_validator - INFO - CRN validated successfully, tenant_id: 1
2026-02-06 19:08:49,889 - common.core.base_service - INFO - Searching entity with query: {'expressions': [{'property': '*', 'condition': 'contains', 'value': ''}]}, tenant: 1, session: adc92e6c-4f12-4b23-8cfe-cea4f37c4570
2026-02-06 19:08:49,889 - common.core.base_adapter - INFO - Searching entity for CRN: :::::::1::, return_type: results_as_entities
2026-02-06 19:08:49,889 - common.auth.authentication_manager - INFO - No valid cached token, fetching new one
2026-02-06 19:08:49,889 - common.auth.authentication_manager - INFO - Fetching new access token from CPD API
2026-02-06 19:08:52,395 - common.auth.authentication_manager - INFO - Token expires at 2026-02-07 07:08:52, will refresh at 2026-02-07 07:06:52 (120s buffer)
2026-02-06 19:08:52,395 - common.auth.authentication_manager - INFO - Successfully fetched CPD token, will refresh at 2026-02-07 07:06:52
2026-02-06 19:08:52,396 - common.auth.token_cache - INFO - Token cached, expires at 2026-02-07 07:06:52
2026-02-06 19:08:52,396 - common.auth.authentication_manager - INFO - Fetching MDM service token for instance 1770096107561137
2026-02-06 19:08:53,344 - common.auth.authentication_manager - INFO - MDM service token received (expires in ~3600s)
2026-02-06 19:08:53,346 - common.core.base_adapter - WARNING - kwargs['headers'] is None, skipping merge
2026-02-06 19:08:55,094 - common.core.base_service - ERROR - API request failed: 400 Client Error: Bad Request for url: https://cpd-zen.apps.510cluster.cp.fyre.ibm.com/1770096107561137/mdm/v1/search?crn=%3A%3A%3A%3A%3A%3A%3A1%3A%3A&limit=1&offset=0&include_total_count=true&return_type=results_as_entities
2026-02-06T13:38:55.110Z [ibm-mdm] [info] Message from server: {"jsonrpc":"2.0","id":4,"result":{"content":[{"type":"text","text":"{\"error\":\"APIError\",\"status_code\":500,\"message\":\"Search request failed: 400 Client Error: Bad Request for url: https://cpd-zen.apps.510cluster.cp.fyre.ibm.com/1770096107561137/mdm/v1/search?crn=%3A%3A%3A%3A%3A%3A%3A1%3A%3A&limit=1&offset=0&include_total_count=true&return_type=results_as_entities\",\"details\":{\"response_text\":null}}"}],"structuredContent":{"result":{"error":"APIError","status_code":500,"message":"Search request failed: 400 Client Error: Bad Request for url: https://cpd-zen.apps.510cluster.cp.fyre.ibm.com/1770096107561137/mdm/v1/search?crn=%3A%3A%3A%3A%3A%3A%3A1%3A%3A&limit=1&offset=0&include_total_count=true&return_type=results_as_entities","details":{"response_text":null}}},"isError":false}} { metadata: undefined }
2026-02-06T13:39:00.098Z [ibm-mdm] [info] Message from client: {"method":"tools/call","params":{"name":"search_master_data","arguments":{"request":{"search_type":"entity","query":{"expressions":[{"property":"record_type","condition":"equal","value":"person"}]},"limit":1,"include_total_count":true}}},"jsonrpc":"2.0","id":5} { metadata: undefined }
2026-02-06 19:09:00,099 - mcp.server.lowlevel.server - INFO - Processing request of type CallToolRequest
2026-02-06 19:09:00,099 - common.domain.crn_validator - INFO - Using default on-prem CRN for cpd platform: :::::::1::
2026-02-06 19:09:00,099 - common.domain.crn_validator - INFO - CRN validated successfully, tenant_id: 1
2026-02-06 19:09:00,099 - common.core.base_service - INFO - Searching entity with query: {'expressions': [{'property': 'record_type', 'condition': 'equal', 'value': 'person'}]}, tenant: 1, session: adc92e6c-4f12-4b23-8cfe-cea4f37c4570
2026-02-06 19:09:00,099 - common.core.base_adapter - INFO - Searching entity for CRN: :::::::1::, return_type: results_as_entities
2026-02-06 19:09:00,099 - common.auth.authentication_manager - INFO - Fetching MDM service token for instance 1770096107561137
2026-02-06 19:09:01,189 - common.auth.authentication_manager - INFO - MDM service token received (expires in ~3600s)
2026-02-06 19:09:01,189 - common.core.base_adapter - WARNING - kwargs['headers'] is None, skipping merge
2026-02-06 19:09:04,460 - common.core.base_adapter - INFO - POST search - Transaction ID: ecb39b03-81d1-4617-b787-360e48490878
2026-02-06T13:39:04.475Z [ibm-mdm] [info] Message from server: {"jsonrpc":"2.0","id":5,"result":{"content":[{"type":"text","text":"{\"results\":[{\"attributes\":{\"birth_date\":[{\"value\":\"1995-07-01\"}],\"collection_id\":\"83ba6ab4-c9c1-432c-ac5f-bbb94303b2aa\",\"entity_last_updated\":\"1770384363268\",\"gender\":[...[2919 chars truncated]..._as_entities&offset=0&limit=1"},"last":{"href":"https://cpd-zen.apps.510cluster.cp.fyre.ibm.com/1770096107561137/mdm/v1/search?crn=%3A%3A%3A%3A%3A%3A%3A1%3A%3A&include_total_count=true&return_type=results_as_entities&offset=56&limit=1"}}},"isError":false}} { metadata: undefined }
2026-02-06T13:40:19.314Z [ibm-mdm] [info] Message from client: {"method":"tools/call","params":{"name":"search_master_data","arguments":{"request":{"limit":10,"query":{"expressions":[{"value":"person","property":"record_type","condition":"equal"}]},"search_type":"entity","include_total_count":true}}},"jsonrpc":"2.0","id":6} { metadata: undefined }
2026-02-06 19:10:19,315 - mcp.server.lowlevel.server - INFO - Processing request of type CallToolRequest
2026-02-06 19:10:19,315 - common.domain.crn_validator - INFO - Using default on-prem CRN for cpd platform: :::::::1::
2026-02-06 19:10:19,316 - common.domain.crn_validator - INFO - CRN validated successfully, tenant_id: 1
2026-02-06 19:10:19,316 - common.core.base_service - INFO - Searching entity with query: {'expressions': [{'value': 'person', 'property': 'record_type', 'condition': 'equal'}]}, tenant: 1, session: adc92e6c-4f12-4b23-8cfe-cea4f37c4570
2026-02-06 19:10:19,316 - common.core.base_adapter - INFO - Searching entity for CRN: :::::::1::, return_type: results_as_entities
2026-02-06 19:10:19,316 - common.auth.authentication_manager - INFO - Fetching MDM service token for instance 1770096107561137
2026-02-06 19:10:20,387 - common.auth.authentication_manager - INFO - MDM service token received (expires in ~3600s)
2026-02-06 19:10:20,391 - common.core.base_adapter - WARNING - kwargs['headers'] is None, skipping merge
2026-02-06 19:10:22,732 - common.core.base_adapter - INFO - POST search - Transaction ID: 2663e556-3620-47f2-bd7b-95b330b8d045
2026-02-06T13:40:22.749Z [ibm-mdm] [info] Message from server: {"jsonrpc":"2.0","id":6,"result":{"content":[{"type":"text","text":"{\"results\":[{\"attributes\":{\"birth_date\":{\"value\":\"1953-05-00\"},\"collection_id\":\"83ba6ab4-c9c1-432c-ac5f-bbb94303b2aa\",\"entity_last_updated\":\"1770384364526\",\"gender\":{\"...[17997 chars truncated]...s_entities&offset=0&limit=10"},"last":{"href":"https://cpd-zen.apps.510cluster.cp.fyre.ibm.com/1770096107561137/mdm/v1/search?crn=%3A%3A%3A%3A%3A%3A%3A1%3A%3A&include_total_count=true&return_type=results_as_entities&offset=50&limit=10"}}},"isError":false}} { metadata: undefined }
```