### PR TITLE
feat: add per-request identity propagation for multi-user MCP access

### DIFF
--- a/src/common/auth/authentication_manager.py
+++ b/src/common/auth/authentication_manager.py
@@ -21,6 +21,7 @@ from datetime import datetime, timedelta
 
 from config import Config
 from common.auth.token_cache import TokenCache
+from common.auth.user_token_context import get_user_token
 
 # Disable SSL warnings when verify=False is used
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -343,6 +344,7 @@ class AuthenticationManager:
         Raises:
             requests.exceptions.RequestException: If token fetch fails
         """
+        # logic to get the token from contextVar, if it doesn't exist fallback to
         # Try to get cached token
         token = self._token_cache.get()
         
@@ -361,17 +363,38 @@ class AuthenticationManager:
     
     def get_auth_headers(self) -> Dict[str, str]:
         """
-        Get authentication headers based on platform.
-        
-        For CPD platform: Uses bearer token with automatic refresh
-        For cloud platform: Uses bearer token with automatic refresh
-        
+        Get authentication headers for the current request.
+
+        Per-request user token (set by UserTokenMiddleware from the caller's
+        IBM IAM bearer token) takes precedence over the shared service-account
+        token.  Falls back to service-account when no user token is present,
+        e.g. in stdio mode without a __mdm_auth__ arg or for background jobs.
+
         Returns:
-            Headers dictionary with authentication
-        
+            Headers dictionary with Authorization and content-type fields.
+
         Raises:
-            requests.exceptions.RequestException: If token fetch fails (for cpd/cloud)
+            requests.exceptions.RequestException: If service-account token fetch fails.
         """
+        # Per-request identity: check ContextVar set by UserTokenMiddleware first.
+        user_token = get_user_token()
+        if user_token:
+            self.logger.info(
+                "[token-propagation] HOP 5 (auth-manager): using per-user token from "
+                "ContextVar (prefix: %s...)",
+                user_token[:8],
+            )
+            return {
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {user_token}",
+            }
+
+        self.logger.debug(
+            "[token-propagation] HOP 5 (auth-manager): no user token in ContextVar — "
+            "using service-account credentials"
+        )
+
         try:
             headers = {
                 "Content-Type": "application/json",

--- a/src/common/auth/token_middleware.py
+++ b/src/common/auth/token_middleware.py
@@ -1,0 +1,132 @@
+# Copyright [2026] [IBM]
+# Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+# See the LICENSE file in the project root for license information.
+
+"""
+FastMCP middleware that propagates the caller's identity into a per-request ContextVar.
+
+Two injection strategies are supported, one per transport:
+
+HTTP (streamable_http / sse)
+    The agentic-AI microservice's TokenInjectingInterceptor stamps the user's IAM
+    token into the Authorization header of each MCP tool call.  This middleware
+    reads that header from the Starlette request stored in _current_http_request
+    and stores the bearer token in the per-request ContextVar.
+
+stdio
+    HTTP headers are unavailable over stdin/stdout.  Instead, the agentic-AI
+    microservice's TokenInjectingInterceptor injects credentials as a special
+    "__mdm_auth__" key in the tool call's arguments.  This middleware pops that
+    key from the arguments before the tool function sees them, and stores the
+    bearer token in the same ContextVar.
+
+In both cases, AuthenticationManager.get_auth_headers() reads the ContextVar and
+returns per-user headers when a token is present, falling back to the shared
+service-account token when it is None.
+"""
+
+import logging
+import mcp.types as mt
+
+from fastmcp.server.middleware.middleware import CallNext, Middleware, MiddlewareContext
+from fastmcp.tools.base import ToolResult
+
+from common.auth.user_token_context import reset_user_token, set_user_token
+
+logger = logging.getLogger(__name__)
+
+# Must match _MDM_STDIO_CRED_KEY in mdm_mcp_tools.py (agentic-AI microservice).
+_MDM_STDIO_CRED_KEY = "__mdm_auth__"
+
+
+class UserTokenMiddleware(Middleware):
+    """
+    Unified identity-propagation middleware for HTTP and stdio transports.
+
+    HTTP  → reads Authorization header from the current Starlette request.
+    stdio → pops __mdm_auth__ from tool call arguments, extracts access_token.
+
+    Sets the per-request ContextVar before calling the next handler and resets
+    it in the finally block so the value never leaks into the next tool call.
+    """
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        from fastmcp.server.http import _current_http_request
+
+        reset_token = None
+        tool_name = context.message.name
+        http_request = _current_http_request.get()
+
+        if http_request is not None:
+            # ── HTTP transport ──────────────────────────────────────────────
+            auth_header = http_request.headers.get("authorization", "")
+            if auth_header.startswith("Bearer "):
+                bearer = auth_header[len("Bearer "):]
+                if bearer:
+                    reset_token = set_user_token(bearer)
+                    logger.info(
+                        "[token-propagation] HOP 4 (http): per-user token extracted from "
+                        "Authorization header for tool '%s' and stored in server ContextVar "
+                        "(prefix: %s...)",
+                        tool_name,
+                        bearer[:8],
+                    )
+                else:
+                    logger.warning(
+                        "[token-propagation] HOP 4 (http): Authorization header present but "
+                        "Bearer value is empty for tool '%s' — using service-account credentials",
+                        tool_name,
+                    )
+            else:
+                logger.info(
+                    "[token-propagation] HOP 4 (http): no Bearer token in Authorization "
+                    "header for tool '%s' — using service-account credentials",
+                    tool_name,
+                )
+        else:
+            # ── stdio transport ─────────────────────────────────────────────
+            args = dict(context.message.arguments or {})
+            creds = args.pop(_MDM_STDIO_CRED_KEY, None)
+
+            if creds:
+                token = creds.get("access_token")
+                if token:
+                    # Strip credential key before the tool function sees the args
+                    context.message.arguments = args
+                    reset_token = set_user_token(token)
+                    logger.info(
+                        "[token-propagation] HOP 4 (stdio): per-user token extracted from "
+                        "'%s' arg for tool '%s' and stored in server ContextVar (prefix: %s...)",
+                        _MDM_STDIO_CRED_KEY,
+                        tool_name,
+                        token[:8],
+                    )
+                else:
+                    logger.warning(
+                        "[token-propagation] HOP 4 (stdio): '%s' arg present but no "
+                        "access_token for tool '%s' — using service-account credentials",
+                        _MDM_STDIO_CRED_KEY,
+                        tool_name,
+                    )
+            else:
+                logger.info(
+                    "[token-propagation] HOP 4 (stdio): no '%s' arg for tool '%s' — "
+                    "using service-account credentials",
+                    _MDM_STDIO_CRED_KEY,
+                    tool_name,
+                )
+
+        try:
+            return await call_next(context)
+        finally:
+            if reset_token is not None:
+                reset_user_token(reset_token)
+                logger.debug(
+                    "[token-propagation] HOP 4: user token cleared from server "
+                    "ContextVar after tool '%s' completed",
+                    tool_name,
+                )

--- a/src/common/auth/user_token_context.py
+++ b/src/common/auth/user_token_context.py
@@ -1,0 +1,32 @@
+# Copyright [2026] [IBM]
+# Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+# See the LICENSE file in the project root for license information.
+
+"""
+Per-request user token context for identity propagation.
+
+Stores the caller's IBM IAM bearer token in an asyncio ContextVar so that
+BaseMDMAdapter can use it instead of the shared service-account token.
+The value is set by UserTokenMiddleware at the start of each tool call and
+reset (not cleared) when the call completes, preserving any outer value.
+"""
+
+from contextvars import ContextVar, Token
+from typing import Optional
+
+_user_token: ContextVar[Optional[str]] = ContextVar("_user_token", default=None)
+
+
+def set_user_token(token: str) -> Token:
+    """Store token and return the reset token needed to undo the set."""
+    return _user_token.set(token)
+
+
+def reset_user_token(reset_token: Token) -> None:
+    """Restore the ContextVar to the value it held before set_user_token was called."""
+    _user_token.reset(reset_token)
+
+
+def get_user_token() -> Optional[str]:
+    """Return the per-request user token, or None if running in service-account mode."""
+    return _user_token.get()

--- a/src/common/core/base_adapter.py
+++ b/src/common/core/base_adapter.py
@@ -20,6 +20,7 @@ from typing import Dict, Any, Optional
 
 from config import Config
 from common.auth.authentication_manager import AuthenticationManager
+from common.auth.user_token_context import get_user_token  # used only for 401 retry decision
 
 logger = logging.getLogger(__name__)
 
@@ -122,9 +123,15 @@ class BaseMDMAdapter(ABC):
         Raises:
             requests.exceptions.RequestException: If request fails
         """
-        # Get auth headers from auth manager
+        # get_auth_headers() checks the per-request ContextVar first (set by
+        # UserTokenMiddleware) and falls back to service-account when it is None.
         headers = self._auth_manager.get_auth_headers()
-        
+        self.logger.info(
+            "[token-propagation] HOP 5 (mdm-api): MDM API call to %s using %s",
+            url,
+            "per-user token" if get_user_token() else "service-account token",
+        )
+
         # Defensive check: ensure headers is a dict
         if headers is None:
             self.logger.error("Authentication manager returned None for headers, using empty dict")
@@ -146,19 +153,28 @@ class BaseMDMAdapter(ABC):
         # Execute request
         response = requests.request(method, url, **kwargs)
         
-        # Handle 401 by invalidating token and retrying once
+        # Handle 401 by retrying once.
+        # In service-account mode, invalidate the cached token so a fresh one is fetched.
+        # In per-request user-token mode, the token came from the caller; do not attempt
+        # a service-account refresh — surface the 401 directly so the caller can re-auth.
         if response.status_code == 401:
-            self.logger.warning("Got 401, invalidating token and retrying")
-            self._auth_manager.invalidate_token()
-            
-            # Get fresh auth headers
-            headers = self._auth_manager.get_auth_headers()
-            if 'headers' in kwargs:
-                headers.update(kwargs['headers'])
-            kwargs['headers'] = headers
-            
-            # Retry request
-            response = requests.request(method, url, **kwargs)
+            user_token = get_user_token()
+            if user_token:
+                self.logger.warning(
+                    "[token-propagation] HOP 5 (mdm-api): 401 from MDM API with per-user token "
+                    "(prefix: %s...) — NOT retrying, caller must re-authenticate", user_token[:8]
+                )
+            else:
+                self.logger.warning(
+                    "[token-propagation] HOP 5 (mdm-api): 401 from MDM API in service-account "
+                    "mode — invalidating cached token and retrying once"
+                )
+                self._auth_manager.invalidate_token()
+                headers = self._auth_manager.get_auth_headers()
+                if 'headers' in kwargs:
+                    headers.update(kwargs['headers'])
+                kwargs['headers'] = headers
+                response = requests.request(method, url, **kwargs)
         
         return response
     

--- a/src/data_ms/search/tool_models.py
+++ b/src/data_ms/search/tool_models.py
@@ -50,11 +50,6 @@ class SearchMasterDataRequest(BaseModel):
         description="Whether to include total count in response"
     )
     
-    crn: Optional[str] = Field(
-        None,
-        description="Cloud Resource Name identifying the tenant"
-    )
-    
     include_attributes: Optional[List[str]] = Field(
         None,
         description="Optional list of attribute paths to include in results (e.g., ['legal_name.given_name', 'address.city'])"

--- a/src/data_ms/search/tools.py
+++ b/src/data_ms/search/tools.py
@@ -28,6 +28,7 @@ def get_search_service() -> SearchService:
 
 def search_master_data(
     ctx: Context,
+    crn: Optional[str],
     request: SearchMasterDataRequest
 ) -> SearchResponse:
     """
@@ -58,6 +59,7 @@ def search_master_data(
     
     Args:
         ctx: MCP Context object (automatically injected) - provides session information
+        crn: Cloud Resource Name identifying the tenant (optional, defaults to On-Prem tenant)
         request: SearchRecordsRequest containing:
             - search_type: Type of data to search for. Options: "record", "entity", "relationship", "hierarchy_node"
             - query: The search query object containing expressions and operations. Structure:
@@ -98,7 +100,6 @@ def search_master_data(
             - limit: Maximum number of results to return (max 50, default: 10)
             - offset: Number of results to skip for pagination (default: 0)
             - include_total_count: Whether to include total count in response (default: true)
-            - crn: Cloud Resource Name identifying the tenant (optional, defaults to On-Prem tenant)
     
     Returns:
         Search results containing matched records with pagination info
@@ -247,7 +248,7 @@ def search_master_data(
         limit=request.limit,
         offset=request.offset,
         include_total_count=request.include_total_count,
-        crn=request.crn,
+        crn=crn,
         include_attributes=request.include_attributes,
         exclude_attributes=request.exclude_attributes
     )

--- a/src/server.py
+++ b/src/server.py
@@ -21,6 +21,9 @@ from fastmcp.tools.tool import Tool
 # Import configuration
 from config import Config
 
+# Import identity propagation middleware
+from common.auth.token_middleware import UserTokenMiddleware
+
 # Import your tools
 from data_ms.search.tools import search_master_data
 from data_ms.records.tools import get_record_by_id, get_records_entities_by_record_id
@@ -37,8 +40,8 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# Initialize MCP
-mcp = FastMCP("mdm-mcp-server")
+# Initialize MCP with identity-propagation middleware
+mcp = FastMCP("mdm-mcp-server", middleware=[UserTokenMiddleware()])
 
 # Get tools mode from configuration
 TOOLS_MODE = Config.MCP_TOOLS_MODE.lower()
@@ -144,7 +147,7 @@ def main():
         port_arg = args.port
         port = int(os.getenv("PORT", str(port_arg)))
         logger.info(f"Starting MCP server on port {port}")
-        mcp.run(transport="streamable-http",  port=port)
+        mcp.run(transport="streamable-http", port=port)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Introduces a ContextVar-based identity propagation chain so each caller's IBM IAM bearer token flows transparently from the HTTP request through the MCP protocol to the IBM MDM API, without recreating the MCP client or leaking tokens across concurrent requests.

Changes:
- common/auth/user_token_context.py (new): ContextVar that holds the per-request user token with set/reset/get helpers using Token-based cleanup (safe for nested/concurrent calls).
- common/auth/token_middleware.py (new): FastMCP Middleware that populates the ContextVar on every tools/call event.
  * HTTP transport: reads Authorization header from _current_http_request.
  * stdio transport: pops __mdm_auth__ credential arg injected by the agentic-AI client, strips it before the tool function sees the args.
- common/auth/authentication_manager.py: get_auth_headers() now checks the ContextVar first; returns per-user Bearer headers when a token is present, falls back to service-account credentials otherwise.
- common/core/base_adapter.py: _execute_request_with_retry() delegates all header building to get_auth_headers(); retains the ContextVar check only to decide whether a 401 should trigger a service-account token refresh (user tokens are not refreshed — 401 is surfaced to the caller).
- server.py: registers UserTokenMiddleware in the FastMCP constructor.