### PR TITLE
feat: add federated search tool for potential match issues 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,4 @@ cython_debug/
 sonar-report.json
 pylint-report.txt
 bandit-report.json
+/.idea

--- a/src/data_ms/adapters/data_ms_adapter.py
+++ b/src/data_ms/adapters/data_ms_adapter.py
@@ -165,4 +165,54 @@ class DataMSAdapter(BaseMDMAdapter):
             f"return_type: {return_type}"
         )
         return self.execute_post(endpoint, search_criteria, params)
-    
+
+    def federated_search(
+        self,
+        query: Dict[str, Any],
+        crn: str,
+        limit: int = 10,
+        offset: int = 0,
+        include_total_count: bool = True,
+        issue_type: str = "potential_match",
+        timezone: str = "UTC",
+        sort_order: str = "desc",
+    ) -> Dict[str, Any]:
+        """
+        Perform a federated search for data quality issues (e.g., potential matches).
+
+        Args:
+            query: Search query containing expressions (same structure as search_master_data)
+            crn: Cloud Resource Name identifying the tenant
+            limit: Maximum number of results to return
+            offset: Number of results to skip for pagination
+            include_total_count: Whether to include total count in response
+            issue_type: Type of data quality issue ("potential_match")
+            timezone: Timezone for date/time values
+            sort_order: Sort order — "asc" or "desc"
+
+        Returns:
+            Federated search results with potential_match_issues and pagination info
+
+        Raises:
+            requests.exceptions.RequestException: If request fails
+        """
+        endpoint = "federated_search"
+
+        params: Dict[str, Any] = {
+            "crn": crn,
+            "limit": str(limit),
+            "offset": str(offset),
+            "include_total_count": str(include_total_count).lower(),
+            "issue_type": issue_type,
+            "timezone": timezone,
+            "sort_order": sort_order,
+        }
+
+        body = {"search_type": "issue", "query": query}
+
+        self.logger.info(
+            "Federated search for issue_type=%s, CRN=%s",
+            issue_type,
+            crn,
+        )
+        return self.execute_post(endpoint, body, params)

--- a/src/data_ms/federated_search/__init__.py
+++ b/src/data_ms/federated_search/__init__.py
@@ -1,0 +1,11 @@
+# Copyright [2026] [IBM]
+# Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+# See the LICENSE file in the project root for license information.
+
+"""
+Federated search module for IBM MDM MCP server.
+"""
+
+from .tools import search_potential_match_issues, FEDERATED_SEARCH_TOOL_DESCRIPTION
+
+__all__ = ['search_potential_match_issues', 'FEDERATED_SEARCH_TOOL_DESCRIPTION']

--- a/src/data_ms/federated_search/service.py
+++ b/src/data_ms/federated_search/service.py
@@ -1,0 +1,75 @@
+# Copyright [2026] [IBM]
+# Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+# See the LICENSE file in the project root for license information.
+
+"""
+Federated search service for IBM MDM MCP server.
+"""
+
+import logging
+import requests
+from typing import Dict, Any, Optional
+
+from fastmcp import Context
+
+from common.core.base_service import BaseService
+from common.domain.crn_validator import CRNValidationError
+from data_ms.adapters.data_ms_adapter import DataMSAdapter
+
+logger = logging.getLogger(__name__)
+
+
+class FederatedSearchService(BaseService):
+    """Service class for federated search (potential match issue) operations."""
+
+    def __init__(self, adapter: Optional[DataMSAdapter] = None):
+        super().__init__(adapter or DataMSAdapter())
+        self.adapter: DataMSAdapter = self.adapter  # type: ignore
+
+    def search_potential_match_issues(
+        self,
+        ctx: Context,
+        query: Dict[str, Any],
+        crn: Optional[str],
+        limit: int,
+        offset: int,
+        include_total_count: bool,
+        issue_type: str,
+        timezone: str,
+        sort_order: str,
+    ) -> Dict[str, Any]:
+        """
+        Execute a federated search for potential match issues.
+
+        Orchestrates CRN validation → adapter call → error handling.
+        """
+        try:
+            session_id, validated_crn, tenant_id = self.validate_session_and_crn(ctx, crn)
+
+            self.logger.info(
+                "Federated search for potential match issues — "
+                "issue_type=%s, tenant=%s, session=%s",
+                issue_type,
+                tenant_id,
+                session_id,
+            )
+
+            return self.adapter.federated_search(
+                query=query,
+                crn=validated_crn,
+                limit=limit,
+                offset=offset,
+                include_total_count=include_total_count,
+                issue_type=issue_type,
+                timezone=timezone,
+                sort_order=sort_order,
+            )
+
+        except CRNValidationError as e:
+            return e.args[0] if e.args else {"error": str(e), "status_code": 400, "message": str(e)}
+
+        except requests.exceptions.RequestException as e:
+            return self.handle_api_error(e, "federated search")
+
+        except Exception as e:
+            return self.handle_unexpected_error(e, "federated search")

--- a/src/data_ms/federated_search/tool_models.py
+++ b/src/data_ms/federated_search/tool_models.py
@@ -1,0 +1,52 @@
+# Copyright [2026] [IBM]
+# Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+# See the LICENSE file in the project root for license information.
+
+"""
+Pydantic models for federated search tool interface.
+"""
+
+from typing import Optional, List, Union
+from pydantic import BaseModel, Field
+
+
+class PotentialMatchIssue(BaseModel):
+    """A single potential match issue record."""
+
+    id: Optional[str] = Field(None, description="Issue identifier")
+    record_ids: Optional[List[str]] = Field(None, description="IDs of records involved")
+    entity_ids: Optional[List[str]] = Field(None, description="IDs of entities involved")
+    score: Optional[float] = Field(None, description="Match confidence score")
+    status: Optional[str] = Field(None, description="Issue status")
+    created_at: Optional[str] = Field(None, description="Issue creation timestamp")
+    updated_at: Optional[str] = Field(None, description="Issue last update timestamp")
+
+    class Config:
+        extra = "allow"
+
+
+class FederatedSearchResponse(BaseModel):
+    """Response model for successful federated search operations."""
+
+    potential_match_issues: List[PotentialMatchIssue] = Field(
+        default_factory=list,
+        description="List of potential match issues"
+    )
+    potential_match_issues_total: Optional[int] = Field(
+        None,
+        description="Total number of matching potential match issues (None when include_total_count=False)"
+    )
+    limit: int = Field(..., description="Maximum results per page")
+    offset: int = Field(..., description="Number of results skipped")
+
+
+class FederatedSearchErrorResponse(BaseModel):
+    """Error response model for federated search operations."""
+
+    error: str = Field(..., description="Error type identifier")
+    status_code: int = Field(..., description="HTTP status code")
+    message: str = Field(..., description="Human-readable error message")
+    details: Optional[dict] = Field(None, description="Additional error details")
+
+
+FederatedSearchResult = Union[FederatedSearchResponse, FederatedSearchErrorResponse]

--- a/src/data_ms/federated_search/tools.py
+++ b/src/data_ms/federated_search/tools.py
@@ -1,0 +1,146 @@
+# Copyright [2026] [IBM]
+# Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+# See the LICENSE file in the project root for license information.
+
+"""
+Federated search tool for IBM MDM MCP server.
+"""
+
+import logging
+from typing import Annotated, Literal, Optional
+
+from fastmcp import Context
+from pydantic import Field
+
+from .service import FederatedSearchService
+from .tool_models import FederatedSearchResult, FederatedSearchResponse, FederatedSearchErrorResponse
+
+logger = logging.getLogger(__name__)
+
+_federated_search_service: Optional[FederatedSearchService] = None
+
+
+def get_federated_search_service() -> FederatedSearchService:
+    global _federated_search_service
+    if _federated_search_service is None:
+        _federated_search_service = FederatedSearchService()
+    return _federated_search_service
+
+
+def search_potential_match_issues(
+    ctx: Context,
+    query: dict,
+    crn: Optional[str] = None,
+    limit: Annotated[int, Field(ge=0, le=50, description="Maximum number of results to return (0-50). Use 0 with include_total_count=true for count-only queries.")] = 10,
+    offset: Annotated[int, Field(ge=0, description="Number of results to skip for pagination")] = 0,
+    include_total_count: bool = True,
+    issue_type: str = "potential_match",
+    timezone: str = "UTC",
+    sort_order: Literal["asc", "desc"] = "desc",
+) -> FederatedSearchResult:
+    """
+    Search for potential match issues in IBM MDM using the federated search endpoint.
+    """
+    service = get_federated_search_service()
+
+    result = service.search_potential_match_issues(
+        ctx=ctx,
+        query=query,
+        crn=crn,
+        limit=limit,
+        offset=offset,
+        include_total_count=include_total_count,
+        issue_type=issue_type,
+        timezone=timezone,
+        sort_order=sort_order,
+    )
+
+    if "error" in result:
+        return FederatedSearchErrorResponse(**result)
+    return FederatedSearchResponse(**result)
+
+
+FEDERATED_SEARCH_TOOL_DESCRIPTION = """
+Search for potential match issues in IBM MDM using the federated search endpoint.
+
+Use this tool when the user asks about potential matches, duplicate records, or
+potential match issues — NOT for general master data search (use search_master_data for that).
+
+**When to use**:
+- User asks: "Show me potential match issues", "Find potential duplicates", "List potential matches"
+- User wants to review records that MDM flagged as potential matches for merging
+- Does NOT require calling get_data_model() first
+
+**Query structure** (same expression syntax as search_master_data):
+- Browse all issues:  {"expressions": [{"property": "*", "condition": "equal", "value": "*"}]}
+- Filter by a field: {"expressions": [{"property": "legal_name.last_name", "condition": "equal", "value": "Smith"}]}
+
+Args:
+    ctx: MCP Context object (automatically injected)
+    query: Search query with expressions. Use property="*", condition="equal", value="*" to list all issues.
+    crn: Cloud Resource Name identifying the tenant (optional, defaults to configured tenant)
+    limit: Maximum number of results to return (0-50, default: 10). Use 0 with include_total_count=true for count-only queries.
+    offset: Number of results to skip for pagination (default: 0)
+    include_total_count: Whether to include total count in response (default: true)
+    issue_type: Type of data quality issue to search (default: "potential_match")
+    timezone: IANA timezone name for date/time values in results (default: "UTC"). Examples: "America/New_York", "Europe/London", "Asia/Tokyo"
+    sort_order: Sort order for results — "asc" (oldest first) or "desc" (newest first, default)
+
+Returns:
+    Potential match issues with pagination info:
+    - potential_match_issues: list of issue records
+    - potential_match_issues_total: total number of matching issues (when include_total_count=true)
+    - limit / offset: pagination metadata
+
+Examples:
+    1. List all potential match issues (newest first):
+       search_potential_match_issues(
+           query={"expressions": [{"property": "*", "condition": "equal", "value": "*"}]}
+       )
+
+    2. Count total potential match issues without fetching records:
+       search_potential_match_issues(
+           query={"expressions": [{"property": "*", "condition": "equal", "value": "*"}]},
+           limit=0,
+           include_total_count=True
+       )
+
+    3. Filter by a specific field — issues involving records with last name "Smith":
+       search_potential_match_issues(
+           query={"expressions": [{"property": "legal_name.last_name", "condition": "equal", "value": "Smith"}]}
+       )
+
+    4. Fuzzy match — issues involving records with a name similar to "Johnson":
+       search_potential_match_issues(
+           query={"expressions": [{"property": "legal_name.last_name", "condition": "fuzzy", "value": "Johnson"}]}
+       )
+
+    5. Sort oldest-first — useful for reviewing issues in the order they were created:
+       search_potential_match_issues(
+           query={"expressions": [{"property": "*", "condition": "equal", "value": "*"}]},
+           sort_order="asc"
+       )
+
+    6. Display dates in a specific timezone:
+       search_potential_match_issues(
+           query={"expressions": [{"property": "*", "condition": "equal", "value": "*"}]},
+           timezone="America/New_York"
+       )
+
+    7. Paginate — second page of 10 results:
+       search_potential_match_issues(
+           query={"expressions": [{"property": "*", "condition": "equal", "value": "*"}]},
+           limit=10,
+           offset=10
+       )
+
+    8. Paginate in ascending order — process all issues oldest-to-newest, third page:
+       search_potential_match_issues(
+           query={"expressions": [{"property": "*", "condition": "equal", "value": "*"}]},
+           limit=10,
+           offset=20,
+           sort_order="asc"
+       )
+"""
+
+search_potential_match_issues.__doc__ = FEDERATED_SEARCH_TOOL_DESCRIPTION

--- a/src/data_ms/search/tool_models.py
+++ b/src/data_ms/search/tool_models.py
@@ -34,9 +34,9 @@ class SearchMasterDataRequest(BaseModel):
     
     limit: int = Field(
         default=10,
-        ge=1,
+        ge=0,
         le=50,
-        description="Maximum number of results to return (1-50)"
+        description="Maximum number of results to return (0-50). Use 0 with include_total_count=true for count-only queries."
     )
     
     offset: int = Field(

--- a/src/data_ms/search/tools.py
+++ b/src/data_ms/search/tools.py
@@ -7,12 +7,12 @@ Search tools for IBM MDM MCP server.
 """
 
 import logging
-from typing import Annotated, List, Literal, Optional
+from typing import Annotated, List, Literal, Optional, Union
 
 from fastmcp import Context
 from pydantic import Field
 from .service import SearchService
-from .tool_models import SearchResponse, SearchMasterDataRequest, SearchMasterDataResponse, SearchErrorResponse
+from .tool_models import SearchResponse, SearchMasterDataResponse, SearchErrorResponse
 
 logger = logging.getLogger(__name__)
 
@@ -42,9 +42,9 @@ def search_master_data(
         description="Optional list of filters to narrow down results"
     )] = None,
     limit: Annotated[int, Field(
-        ge=1,
+        ge=0,
         le=50,
-        description="Maximum number of results to return (1-50)"
+        description="Maximum number of results to return (0-50). Use 0 with include_total_count=true for count-only queries."
     )] = 10,
     offset: Annotated[int, Field(
         ge=0,
@@ -53,15 +53,15 @@ def search_master_data(
     include_total_count: Annotated[bool, Field(
         description="Whether to include total count in response"
     )] = True,
-    include_attributes: Annotated[Optional[List[str]], Field(
-        description=("Optional list of attribute paths to include in results (e.g., ['legal_name.given_name', 'address.city'])." 
+    include_attributes: Annotated[Optional[Union[List[str], str]], Field(
+        description=("Optional list of attribute paths to include in results (e.g., ['legal_name.given_name', 'address.city'])."
                      "DO NOT set this field unless the user explicitly asks to see only specific attributes."
                      "When null (default), all attributes are returned - this is the correct behavior "
                      "for most queries. Only use this to narrow results when the user says something like "
                      "'show me only names and addresses'."
                      )
     )] = None,
-    exclude_attributes: Annotated[Optional[List[str]], Field(
+    exclude_attributes: Annotated[Optional[Union[List[str], str]], Field(
         description=("Optional list of attribute paths to exclude from results (e.g., ['legal_name.given_name', 'address.city'])"
                      "DO NOT set this field unless the user explicitly asks to hide specific attributes. "
                      "When null (default), no attributes are excluded."
@@ -71,6 +71,19 @@ def search_master_data(
     """
     Search Master Data
    """
+    if isinstance(include_attributes, str):
+        include_attributes = None if include_attributes in ("*", "") else [include_attributes]
+    elif isinstance(include_attributes, list) and not include_attributes:
+        include_attributes = None
+
+    if isinstance(exclude_attributes, str):
+        exclude_attributes = None if exclude_attributes in ("*", "") else [exclude_attributes]
+    elif isinstance(exclude_attributes, list) and not exclude_attributes:
+        exclude_attributes = None
+
+    if isinstance(filters, list) and not filters:
+        filters = None
+
     service = get_search_service()
 
     result = service.search_master_data(

--- a/src/server.py
+++ b/src/server.py
@@ -26,6 +26,7 @@ from common.auth.token_middleware import UserTokenMiddleware
 
 # Import your tools
 from data_ms.search.tools import search_master_data, SEARCH_TOOL_DESCRIPTION
+from data_ms.federated_search.tools import search_potential_match_issues, FEDERATED_SEARCH_TOOL_DESCRIPTION
 from data_ms.records.tools import get_record_by_id, get_records_entities_by_record_id
 from data_ms.entities.tools import get_entity
 from model_ms.model.tools import get_data_model
@@ -50,6 +51,7 @@ logger.info(f"Registering tools in '{TOOLS_MODE}' mode")
 
 # Register core tools (always available)
 mcp.add_tool(Tool.from_function(search_master_data, name="search_master_data", description=SEARCH_TOOL_DESCRIPTION))
+mcp.add_tool(Tool.from_function(search_potential_match_issues, name="search_potential_match_issues", description=FEDERATED_SEARCH_TOOL_DESCRIPTION))
 mcp.add_tool(Tool.from_function(get_data_model, name="get_data_model"))
 
 # Register additional tools only in full mode
@@ -116,6 +118,18 @@ User: "Count entities by type"
 2. For each type: search_master_data(search_type="entity", filters=[{"type":"entity","values":["person"]}], limit=1, include_total_count=true)
 3. Use total_count from response for statistics
 
+**Tool Selection — search_master_data vs search_potential_match_issues:**
+
+| User Intent | Tool to Use |
+|---|---|
+| Find people, organizations, records, entities | `search_master_data` |
+| Potential matches / potential duplicates / data quality issues | `search_potential_match_issues` |
+
+`search_potential_match_issues` wraps the `/federated_search` endpoint and returns `potential_match_issues` (not `results`).
+- To list all issues: query={"expressions": [{"property": "*", "condition": "equal", "value": "*"}]}
+- To count only: add limit=0, include_total_count=True
+- Does NOT require fetching the data model first
+
 **Common Mistakes to Avoid:**
 - ❌ Calling search_master_data without ever fetching the data model in the session
 - ❌ Fetching data model repeatedly when you already have it
@@ -123,6 +137,7 @@ User: "Count entities by type"
 - ❌ Using property="*" as first attempt (only use as fallback)
 - ❌ Using search_type="record" when user asks about entities (default to "entity")
 - ❌ Giving up after 0 results or validation error (try full-text search with property="*")
+- ❌ Using search_master_data for potential match / duplicate queries (use search_potential_match_issues instead)
 
 **Current Task:**
 Await user query and begin Step 1 immediately.


### PR DESCRIPTION
- Add search_potential_match_issues MCP tool via POST /mdm/v1/federated_search
- Wire new tool into server.py alongside existing search tools
- Fix ValidationError: widen include_attributes/exclude_attributes to Union[List[str], str] to handle LLM sending '*' string; normalize to None/list before service call